### PR TITLE
Fix sensitivity params, Add Example for new RHS and OBJ

### DIFF
--- a/Datasets/milp_obj_test.mps
+++ b/Datasets/milp_obj_test.mps
@@ -1,0 +1,21 @@
+NAME	simple_milp
+ROWS
+ N 	 OBJROW
+ L	 R0
+ L	 R1
+ L	 R2 
+COLUMNS
+ X0	 OBJROW 	1	 R0 	-3	 
+ X1	 OBJROW 	1	 R1 	-1	 
+ X2	 OBJROW 	1	 R0 	-3   
+ X3	 OBJROW 	1	 R1     -5	 
+ 	
+RHS
+ RHS	 R0 	 -3
+ RHS	 R1 	 -3
+BOUNDS
+ UI BOUND	X0	 1e+30	
+ UI BOUND	X1	 1e+30	
+ UP BOUND	X2	 1e+30	
+ UP BOUND	X3	 1e+30	
+ENDATA

--- a/Examples/Makefile.in
+++ b/Examples/Makefile.in
@@ -21,7 +21,7 @@
 CYGPATH_W = @CYGPATH_W@
 
 EXAMPLES = milp milp2 bicriteria sensitivity \
-	warm_start1 warm_start2 warm_start3
+	warm_start1 warm_start2 warm_start3 rhs_obj_changes
 
 ##############################################################################
 # If you wish to use SYMPHONY through the SYMPHONY OSI interface, 

--- a/Examples/rhs_obj_changes.c
+++ b/Examples/rhs_obj_changes.c
@@ -1,0 +1,94 @@
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <math.h>
+#include <time.h>
+
+#include "symphony.h"
+
+
+// Helper function
+double* generate_rand_array(int n, int l, int u) {
+  double* res = (double *)malloc(n * sizeof(double));
+  for (int i = 0; i < n; i++) {
+    res[i] = (rand() % (u - l + 1)) + l;
+  }
+  return res;
+}
+
+
+int main(int argc, char **argv)
+{   
+      
+   int termcode;
+   int n = 4; // number of variables
+   int m = 2; // number of constraints 
+
+   double *rhs = (double *) malloc(m * sizeof(double));
+   double *coeff = (double *) malloc(n * sizeof(double));
+
+   double *coldObjVal = (double *) malloc(sizeof(double));
+   double *warmObjVal = (double *) malloc(sizeof(double));
+   
+   // Create SYMPHONY environment and load the problem 
+   sym_environment *env = sym_open_environment(); 
+   sym_parse_command_line(env, argc, argv);   
+   sym_load_problem(env);
+
+   // Set the parameters for the warm starting
+   sym_set_int_param(env, "keep_warm_start", TRUE);
+   sym_set_int_param(env, "should_use_rel_br", FALSE);
+   sym_set_int_param(env, "use_hot_starts", FALSE);
+   sym_set_int_param(env, "should_warmstart_node", TRUE);
+   sym_set_int_param(env, "sensitivity_analysis", TRUE);
+   sym_set_int_param(env, "set_obj_upper_lim", FALSE);
+   sym_set_int_param(env, "do_primal_heuristic", FALSE);
+   sym_set_int_param(env, "prep_level", -1);
+   sym_set_int_param(env, "tighten_root_bounds", FALSE);
+   sym_set_int_param(env, "max_sp_size", 100);
+   sym_set_int_param(env, "do_reduced_cost_fixing", FALSE);
+   sym_set_int_param(env, "generate_cgl_cuts", FALSE);
+   sym_set_int_param(env, "max_active_nodes", 1);
+
+   // First solve the original problem
+   // This will create a warm start for the next solve
+   if ((termcode = sym_solve(env)) < 0){
+      printf("PROBLEM INFEASIBLE!\n");
+      return (1);
+   }
+
+   // Set the new RHS
+   rhs = generate_rand_array(m, -1000, -1);
+   for (int i = 0; i < m; i++){
+      sym_set_row_upper(env, i, rhs[i]);
+   }
+
+   // Set the new Obj Coeff
+   coeff = generate_rand_array(n, 1, 1000);
+   for (int i = 0; i < n; i++){
+      sym_set_obj_coeff(env, i, coeff[i]);
+   }
+
+   // Warm solve
+   if ((termcode = sym_warm_solve(env)) < 0){
+      printf("PROBLEM INFEASIBLE!\n");
+      return(1);
+   } 
+   // Get the objective value
+   sym_get_obj_val(env, warmObjVal);
+
+   // Cold solve to check if the values coincide
+   if ((termcode = sym_solve(env)) < 0){
+      printf("PROBLEM INFEASIBLE!\n");
+      return(1);
+   } 
+
+   sym_get_obj_val(env, coldObjVal);
+
+   // These must be equal
+   assert((*warmObjVal) == (*coldObjVal));
+
+   sym_close_environment(env);
+   return 0;
+}  

--- a/src/Master/master.cpp
+++ b/src/Master/master.cpp
@@ -7468,6 +7468,29 @@ SYMPHONYLIB_EXPORT int sym_set_param(sym_environment *env, char *line)
       printf("         features enabled in order to use them.\n\n");
 #endif
       return(0);
+   }else if (strcmp(key, "sensitivity_bounds") == 0 ||
+	    strcmp(key, "TM_sensitivity_bounds") == 0 ){
+#ifdef SENSITIVITY_ANALYSIS
+      READ_INT_PAR(tm_par->sensitivity_bounds);
+      lp_par->sensitivity_bounds = tm_par->sensitivity_bounds;
+#else
+      printf("Warning: Sensitivity analysis features are not currently\n");
+      printf("         enabled. You must rebuild SYMPHONY with these\n");
+      printf("         features enabled in order to use them.\n\n");
+#endif
+      return(0);
+   }
+   else if (strcmp(key, "sensitivity_rhs") == 0 ||
+	    strcmp(key, "TM_sensitivity_rhs") == 0 ){
+#ifdef SENSITIVITY_ANALYSIS
+      READ_INT_PAR(tm_par->sensitivity_rhs);
+      lp_par->sensitivity_rhs = tm_par->sensitivity_rhs;
+#else
+      printf("Warning: Sensitivity analysis features are not currently\n");
+      printf("         enabled. You must rebuild SYMPHONY with these\n");
+      printf("         features enabled in order to use them.\n\n");
+#endif
+      return(0);
    }else if (strcmp(key, "output_mode") == 0 ||
 	    strcmp(key, "TM_output_mode") == 0){
       READ_INT_PAR(tm_par->output_mode);


### PR DESCRIPTION
There was a bug in `sym_set_param()` for which `sensitivity_rhs` and `sensitivity_bound` were not correctly set.
Added a new example to show how to change the RHS and the Obj Function of a MILP and use the warm solve capabilities of SYMPHONY.
Added a MILP toy example.