### PR TITLE
reset Clp termination code to "time limit reached" when seeing "iteration limit reached" in dual simplex resolve

### DIFF
--- a/src/LP/lp_solver.c
+++ b/src/LP/lp_solver.c
@@ -2715,6 +2715,8 @@ int dual_simplex(LPdata *lp_data, int *iterd)
    }else if (si->isIterationLimitReached()){
       term = LP_D_ITLIM;
 #ifdef __OSI_CLP__
+      // YX: reset term if Clp; Clp may return ITLIM at timeout
+      term = LP_TIME_LIMIT;
       /* If max iterations and had switched to primal, bound is no good */
       if (si->getModelPtr()->secondaryStatus() == 10){
 	 term = LP_ABANDONED;

--- a/src/LP/lp_solver.c
+++ b/src/LP/lp_solver.c
@@ -2598,6 +2598,12 @@ int initial_lp_solve (LPdata *lp_data, int *iterd)
    }else if (si->isIterationLimitReached()){
       term = LP_D_ITLIM;
 #ifdef __OSI_CLP__
+      // YX: reset term if needed; Clp may return ITLIM at timeout
+      int itlim_chk = -1;
+      retval = si->getIntParam(OsiMaxNumIteration, itlim_chk);
+      if (si->getIterationCount() < itlim_chk){
+         term = LP_TIME_LIMIT;
+      }
       /* If max iterations and had switched to primal, bound is no good */
       if (si->getModelPtr()->secondaryStatus() == 10){
 	 term = LP_ABANDONED;
@@ -2825,9 +2831,17 @@ int solve_hotstart(LPdata *lp_data, int *iterd)
       term = LP_D_OBJLIM;
    else if (si->isProvenOptimal())
       term = LP_OPTIMAL;
-   else if (si->isIterationLimitReached())
+   else if (si->isIterationLimitReached()){
       term = LP_D_ITLIM;
-   else if (si->isAbandoned())
+#ifdef __OSI_CLP__
+      // YX: reset term if needed; Clp may return ITLIM at timeout
+      int itlim_chk = -1;
+      retval = si->getIntParam(OsiMaxNumIteration, itlim_chk);
+      if (si->getIterationCount() < itlim_chk){
+         term = LP_TIME_LIMIT;
+      }
+#endif
+   }else if (si->isAbandoned())
       term = LP_ABANDONED;
    
    /* if(term == D_UNBOUNDED){

--- a/src/LP/lp_solver.c
+++ b/src/LP/lp_solver.c
@@ -2717,8 +2717,8 @@ int dual_simplex(LPdata *lp_data, int *iterd)
 #ifdef __OSI_CLP__
       // YX: reset term if needed; Clp may return ITLIM at timeout
       int itlim_chk = -1;
-      retval = si->getIntParam(OsiMaxNumIteration, itlim_chk); 
-      if (itlim_chk >= LP_MAX_ITER){
+      retval = si->getIntParam(OsiMaxNumIteration, itlim_chk);
+      if (si->getIterationCount() < itlim_chk){
          term = LP_TIME_LIMIT;
       } 
       /* If max iterations and had switched to primal, bound is no good */

--- a/src/LP/lp_solver.c
+++ b/src/LP/lp_solver.c
@@ -2715,8 +2715,12 @@ int dual_simplex(LPdata *lp_data, int *iterd)
    }else if (si->isIterationLimitReached()){
       term = LP_D_ITLIM;
 #ifdef __OSI_CLP__
-      // YX: reset term if Clp; Clp may return ITLIM at timeout
-      term = LP_TIME_LIMIT;
+      // YX: reset term if needed; Clp may return ITLIM at timeout
+      int itlim_chk = -1;
+      retval = si->getIntParam(OsiMaxNumIteration, itlim_chk); 
+      if (itlim_chk >= LP_MAX_ITER){
+         term = LP_TIME_LIMIT;
+      } 
       /* If max iterations and had switched to primal, bound is no good */
       if (si->getModelPtr()->secondaryStatus() == 10){
 	 term = LP_ABANDONED;


### PR DESCRIPTION
Change the return code in `dual_simplex` from `LP_D_ITLIM` to `LP_TIME_LIMIT` if use Clp.
-  Clp may return "maximum iteration limit reached" flag when it is actually timeout (see `ClpModel::hitMaximumIterations()`). 