### PR TITLE
Updates for linux-ci for OS updates

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -11,7 +11,6 @@ on:
   release:
     types:
       - created
-  workflow_dispatch:
 
 jobs:
   test:
@@ -24,17 +23,13 @@ jobs:
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
         include:
-          - os: macos-12
+          - os: macos-13
             build_static: false
-            flags: CC=clang CXX=clang++ OSX=12
+            flags: CC=clang OSX=13
             download_requirements: brew install metis bash
-          - os: macos-12
+          - os: macos-13
             build_static: false
-            flags: CC=gcc-11 CXX=g++-11 OSX=12
-            download_requirements: brew install metis bash
-          - os: macos-12
-            build_static: false
-            flags: CC=gcc-12 CXX=g++-12 OSX=12
+            flags: CC=gcc-13 CXX=g++-13 OSX=13
             download_requirements: brew install metis bash
     steps:
       - name: Checkout source

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -11,6 +11,7 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -11,6 +11,7 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -11,7 +11,6 @@ on:
   release:
     types:
       - created
-  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Updates for OS (Ubuntu 20, 22 and macos 13)
Compared to Cbc master, only ADD_BUILD_ARGS+=( --disable-shared )
