### PR TITLE
Fix unwanted behavior of CLP when we expect to do dual simplex

### DIFF
--- a/include/sym_lp_solver.h
+++ b/include/sym_lp_solver.h
@@ -229,6 +229,9 @@ typedef struct LPDATA{
    cgl_params  cgl;
 
    int        *frac_var_cnt;
+   // feb223
+   int        *cstat; /* to be used in branching to save the basis */
+   int        *rstat;
 
 }LPdata;
 

--- a/src/LP/lp_branch.c
+++ b/src/LP/lp_branch.c
@@ -1634,7 +1634,7 @@ int select_branching_object(lp_prob *p, int *cuts, branch_obj **candidate)
 		     
 		  } else {
 		     load_basis(lp_data, cstat, rstat);
-		     can->termcode[j] = initial_lp_solve(lp_data, can->iterd+j);
+		     can->termcode[j] = dual_simplex(lp_data, can->iterd+j);
 		     total_iters+=*(can->iterd+j);
 		     
 		  }

--- a/src/LP/lp_branch.c
+++ b/src/LP/lp_branch.c
@@ -250,8 +250,9 @@ int select_branching_object(lp_prob *p, int *cuts, branch_obj **candidate)
    st_time     = used_time(&total_time);
    total_iters = 0;
 
-   int *cstat = lp_data->tmp.i1;
-   int *rstat = lp_data->tmp.i2;
+   
+   int *cstat = lp_data->cstat; //lp_data->tmp.i1;
+   int *rstat = lp_data->rstat; //lp_data->tmp.i2;
 
    get_basis(lp_data, cstat, rstat);
       

--- a/src/LP/lp_solver.c
+++ b/src/LP/lp_solver.c
@@ -58,6 +58,10 @@ void free_lp_arrays(LPdata *lp_data)
    //Anahita
    FREE(lp_data->raysol);
    FREE(lp_data->slacks);
+   // feb223
+   FREE(lp_data->cstat);
+   FREE(lp_data->rstat);
+
    FREE(lp_data->random_hash);
    FREE(lp_data->hashes);
    FREE(lp_data->accepted_ind);
@@ -192,21 +196,26 @@ void size_lp_arrays(LPdata *lp_data, char do_realloc, char set_max,
       if (! do_realloc){
          FREE(lp_data->dualsol);
          lp_data->dualsol = (double *) malloc(lp_data->maxm * DSIZE);
-	 //Anahita
+	      //Anahita
          FREE(lp_data->raysol);
          lp_data->raysol = (double *) malloc(lp_data->maxm * DSIZE);
-	 //
-	 FREE(lp_data->slacks);
-	 lp_data->slacks  = (double *) malloc(lp_data->maxm * DSIZE);
+         
+         FREE(lp_data->slacks);
+         lp_data->slacks  = (double *) malloc(lp_data->maxm * DSIZE);
+         FREE(lp_data->rstat);
+         lp_data->rstat = (int *)malloc((lp_data->maxm) * ISIZE);
      }else{
          lp_data->dualsol = (double *) realloc((char *)lp_data->dualsol,
                                                lp_data->maxm * DSIZE);
-	 //Anahita
-	 lp_data->raysol = (double *) realloc((char *)lp_data->raysol,
-	    lp_data->maxm * DSIZE);
-	 //
-	 lp_data->slacks  = (double *) realloc((void *)lp_data->slacks,
-					       lp_data->maxm * DSIZE);
+         //Anahita
+         lp_data->raysol = (double *) realloc((char *)lp_data->raysol,
+            lp_data->maxm * DSIZE);
+         //
+         lp_data->slacks  = (double *) realloc((void *)lp_data->slacks,
+                           lp_data->maxm * DSIZE);
+         // feb223
+         lp_data->rstat = (int *)realloc((void *)lp_data->rstat,
+                                          (lp_data->maxm) * ISIZE);
       }
       /* rows is realloc'd in either case just to keep the base constr */
       lp_data->rows = (row_data *) realloc((char *)lp_data->rows,
@@ -228,7 +237,10 @@ void size_lp_arrays(LPdata *lp_data, char do_realloc, char set_max,
          FREE(lp_data->heur_solution);
          lp_data->heur_solution = (double *) malloc(lp_data->maxn * DSIZE);
          FREE(lp_data->col_solution);
-         lp_data->col_solution = (double *) malloc(lp_data->maxn * DSIZE);
+         lp_data->col_solution = (double *)malloc(lp_data->maxn * DSIZE);
+         // feb223
+         FREE(lp_data->cstat);
+         lp_data->cstat = (int *)malloc((lp_data->maxn) * ISIZE);
 #ifdef __CPLEX__
 	 FREE(lp_data->lb);
 	 lp_data->lb = (double *) malloc(lp_data->maxn * DSIZE);
@@ -248,6 +260,9 @@ void size_lp_arrays(LPdata *lp_data, char do_realloc, char set_max,
                lp_data->heur_solution, lp_data->maxn * DSIZE);
          lp_data->col_solution = (double *) realloc((char *)
                lp_data->col_solution, lp_data->maxn * DSIZE);
+         // feb223
+         lp_data->cstat = (int *)realloc((void *)lp_data->cstat,
+                                    (lp_data->maxn) * ISIZE);
 #ifdef __CPLEX__
 	 lp_data->lb = (double *) realloc((char *)lp_data->lb,
 					  lp_data->maxn * DSIZE);

--- a/src/LP/lp_solver.c
+++ b/src/LP/lp_solver.c
@@ -2339,11 +2339,22 @@ void open_lp_solver(LPdata *lp_data)
    lp_data->si->messageHandler()->setLogLevel(0);
 #ifdef __OSI_CLP__
    lp_data->si->setupForRepeatedUse();
-   //lp_data->si->setupForRepeatedUse(3,0);
-   //lp_data->si->getModelPtr()->setFactorizationFrequency(200);
-   //lp_data->si->getModelPtr()->setSparseFactorization(true);
-   //lp_data->si->getModelPtr()->setSpecialOptions(524288);
-   //lp_data->si->getModelPtr()->setSpecialOptions(4);   
+   // feb223
+   int options = lp_data->si->getModelPtr()->specialOptions();
+   int moreOptions = lp_data->si->getModelPtr()->moreSpecialOptions();
+   
+   options |= 32           // CLP creates ray while doing dual simplex
+            // + 2048         // CLP does not cruch the problem
+                              // maybe not needed if we recompute dj's on fixed vars ???
+            + 0x08000000;  // CLP computes accurate duals on LP_D_ITLIM
+   moreOptions |= 8192;    // CLP uses dual simplex if it has suggested to do so
+   lp_data->si->getModelPtr()->setSpecialOptions(options);
+   lp_data->si->getModelPtr()->setMoreSpecialOptions(moreOptions);
+   // lp_data->si->setupForRepeatedUse(3,0);
+   // lp_data->si->getModelPtr()->setFactorizationFrequency(200);
+   // lp_data->si->getModelPtr()->setSparseFactorization(true);
+   // lp_data->si->getModelPtr()->setSpecialOptions(524288);
+   // lp_data->si->getModelPtr()->setSpecialOptions(4);
    lp_data->si->getModelPtr()->setPerturbation(50);
    //set cleanup param if unscaled primal is infeasible
    lp_data->si->setCleanupScaling(1);


### PR DESCRIPTION
CLP is hinted to go for dual simplex but it may still go for primal, giving wrong results when in strong branching iteration limit is hit and primal has been done. Moreover, when doing dual simplex, dual solutions may be inaccure at iteration limit. To fix that, some options are set through Osi to make CLP behave as we expect.