### PR TITLE
Fix CLP termcode to LP_TIME_LIMIT only in the case a limit has been set

### DIFF
--- a/SYMPHONY/src/LP/lp_solver.c
+++ b/SYMPHONY/src/LP/lp_solver.c
@@ -2599,10 +2599,14 @@ int initial_lp_solve (LPdata *lp_data, int *iterd)
    }else if (si->isIterationLimitReached()){
       term = LP_D_ITLIM;
 #ifdef __OSI_CLP__
+      double timelimit;
+      ClpDblParam key = ClpMaxWallSeconds;   
+      lp_data->si->getModelPtr()->getDblParam(key, timelimit);
       // YX: reset term if needed; Clp may return ITLIM at timeout
       int itlim_chk = -1;
       retval = si->getIntParam(OsiMaxNumIteration, itlim_chk);
-      if (si->getIterationCount() < itlim_chk){
+      // feb223: but check that a time limit has been actually set
+      if (timelimit > 0 && (si->getIterationCount() < itlim_chk)){
          term = LP_TIME_LIMIT;
       }
       /* If max iterations and had switched to primal, bound is no good */
@@ -2722,12 +2726,16 @@ int dual_simplex(LPdata *lp_data, int *iterd)
    }else if (si->isIterationLimitReached()){
       term = LP_D_ITLIM;
 #ifdef __OSI_CLP__
+      double timelimit;
+      ClpDblParam key = ClpMaxWallSeconds;   
+      lp_data->si->getModelPtr()->getDblParam(key, timelimit);
       // YX: reset term if needed; Clp may return ITLIM at timeout
       int itlim_chk = -1;
       retval = si->getIntParam(OsiMaxNumIteration, itlim_chk);
-      if (si->getIterationCount() < itlim_chk){
+      // feb223: but check that a time limit has been actually set
+      if (timelimit > 0 && (si->getIterationCount() < itlim_chk)){
          term = LP_TIME_LIMIT;
-      } 
+      }
       /* If max iterations and had switched to primal, bound is no good */
       if (si->getModelPtr()->secondaryStatus() == 10){
 	 term = LP_ABANDONED;
@@ -2835,10 +2843,14 @@ int solve_hotstart(LPdata *lp_data, int *iterd)
    else if (si->isIterationLimitReached()){
       term = LP_D_ITLIM;
 #ifdef __OSI_CLP__
+      double timelimit;
+      ClpDblParam key = ClpMaxWallSeconds;   
+      lp_data->si->getModelPtr()->getDblParam(key, timelimit);
       // YX: reset term if needed; Clp may return ITLIM at timeout
       int itlim_chk = -1;
       retval = si->getIntParam(OsiMaxNumIteration, itlim_chk);
-      if (si->getIterationCount() < itlim_chk){
+      // feb223: but check that a time limit has been actually set
+      if (timelimit > 0 && (si->getIterationCount() < itlim_chk)){
          term = LP_TIME_LIMIT;
       }
 #endif


### PR DESCRIPTION
CLP declares "maximum iteration limit reached" also when the time limit is reached. Moreover, when the iteration limit is set to, e.g., `ITER_LIMIT` and  `si->isIterationLimitReached() == True`, it may happen that `si->getIterationCount() < ITER_LIMIT`.

While this issue seems related more to CLP than SYMPHONY, it has been addressed in PR [#199](https://github.com/coin-or/SYMPHONY/pull/199) by declaring `term = LP_TIME_LIMIT` when this inconsistency happens.

Here is proposed a more "robust" solution, by checking that at least a time limit has been previously set to CLP.

This PR fixes issue [#206](https://github.com/coin-or/SYMPHONY/issues/206).