### PR TITLE
Fix warm-start when used through Osi and Pre-processor is on

### DIFF
--- a/src/Master/master.cpp
+++ b/src/Master/master.cpp
@@ -898,7 +898,15 @@ SYMPHONYLIB_EXPORT int sym_solve(sym_environment *env)
       best_sol->has_sol = FALSE;
    }
 
+   /* Mark the MIPDesc as not modified anymore */
    env->mip->is_modified = FALSE;
+   env->mip->change_num = 0;
+   env->mip->var_type_modified = FALSE;
+   env->mip->new_col_num = 0;
+   if(env->mip->cru_vars_num){
+      FREE(env->mip->cru_vars);
+      env->mip->cru_vars_num = 0;
+   }
    
    /* we send environment in just because we may need to 
       update rootdesc and so...*/
@@ -1454,13 +1462,6 @@ SYMPHONYLIB_EXPORT int sym_solve(sym_environment *env)
    }
    env->par.tm_par.warm_start = FALSE;
    env->warm_start->trim_tree = DO_NOT_TRIM;		  	    
-   env->mip->change_num = 0;
-   env->mip->var_type_modified = FALSE;
-   env->mip->new_col_num = 0;
-   if(env->mip->cru_vars_num){
-      FREE(env->mip->cru_vars);
-      env->mip->cru_vars_num = 0;
-   }
 
 #ifdef SYM_COMPILE_IN_LP
    int thread_num;


### PR DESCRIPTION
This PR fixes the underlying assumption that when `sym_solve()` is called, then the problem is considered as not modified anymore or that the modifications have been taken care of already. 

These lines of code were already present, but were executed only **_after_** the solving process had terminated. Hence, throughout the `solve()`, the `MIPDesc` was marked as "modified". However, after `sym_warm_solve()` has been executed, other parts of the code are independent from whether `MIPDesc` is modified or not. 

Hence, we move these lines _**before**_ the pre-processor is called (which may make a copy of the original `MIPDesc`), to avoid that modifications are carried over and may create unwanted behaviors on further `sym_warm_solve()` calls.

This issue arise, e.g., when we use Symphony via Osi to solve modified instances and the pre-processor is on.
 
